### PR TITLE
Prototipo

### DIFF
--- a/lib/utils/pdf_utils.dart
+++ b/lib/utils/pdf_utils.dart
@@ -607,15 +607,21 @@ Future<void> exportClientReceiptToPDF(
             ),
             pw.Text('ID: ${client.id}'),
             pw.SizedBox(height: 10),
-            pw.TableHelper.fromTextArray(
-              headers: ['Tipo', 'Monto', 'Descripción', 'Fecha'],
+            pw.Table.fromTextArray(
+              headers: ['Fecha', 'Descripción', 'Tipo', 'Monto'],
+              headerStyle: pw.TextStyle(
+                fontWeight: pw.FontWeight.bold,
+                color: PdfColors.white,
+              ),
+              headerDecoration: pw.BoxDecoration(color: PdfColors.blue),
+              cellStyle: pw.TextStyle(fontSize: 10),
               data: sorted
                   .map(
                     (tx) => [
+                      tx.date.toLocal().toString().split(' ')[0],
+                      tx.description,
                       tx.type == 'debt' ? 'Deuda' : 'Abono',
                       tx.amount.toStringAsFixed(2),
-                      tx.description,
-                      tx.date.toLocal().toString().split(' ')[0],
                     ],
                   )
                   .toList(),

--- a/lib/widgets/add_global_transaction_modal.dart
+++ b/lib/widgets/add_global_transaction_modal.dart
@@ -111,12 +111,21 @@ class _GlobalTransactionFormState extends State<_GlobalTransactionForm> {
       logError('Monto inválido');
       return;
     }
-    if (_descriptionController.text.trim().isEmpty) {
+    final descText = _descriptionController.text.trim();
+    if (descText.isEmpty) {
       setState(() {
         _error = 'Descripción obligatoria';
         _loading = false;
       });
       logError('Descripción obligatoria');
+      return;
+    }
+    if (descText.length > 30) {
+      setState(() {
+        _error = 'La descripción no puede tener más de 30 caracteres';
+        _loading = false;
+      });
+      logError('Descripción muy larga');
       return;
     }
     // Validar y guardar tasa solo si el campo está visible
@@ -579,11 +588,13 @@ class _GlobalTransactionFormState extends State<_GlobalTransactionForm> {
         const SizedBox(height: 12),
         TextField(
           controller: _descriptionController,
+          maxLength: 30,
           decoration: InputDecoration(
             labelText: 'Descripción',
             border: OutlineInputBorder(borderRadius: BorderRadius.circular(8)),
             prefixIcon: Icon(Icons.description),
             isDense: true,
+            counterText: '',
           ),
           maxLines: 2,
         ),

--- a/lib/widgets/add_global_transaction_modal.dart
+++ b/lib/widgets/add_global_transaction_modal.dart
@@ -55,9 +55,13 @@ class _GlobalTransactionFormState extends State<_GlobalTransactionForm> {
   final _amountController = TextEditingController();
   final _descriptionController = TextEditingController();
   String? _type;
-  String _currencyCode = 'USD';
+  String? _currencyCode;
   // FIX: Normalizar la fecha inicial a medianoche para evitar que la hora interfiera con el ordenamiento.
-  DateTime _selectedDate = DateTime(DateTime.now().year, DateTime.now().month, DateTime.now().day);
+  DateTime _selectedDate = DateTime(
+    DateTime.now().year,
+    DateTime.now().month,
+    DateTime.now().day,
+  );
   Client? _selectedClient;
   String? _error;
   bool _loading = false;
@@ -90,7 +94,7 @@ class _GlobalTransactionFormState extends State<_GlobalTransactionForm> {
       logError('Debes seleccionar Deuda o Abono');
       return;
     }
-    if (_currencyCode.isEmpty) {
+    if (_currencyCode == null || _currencyCode!.isEmpty) {
       setState(() {
         _error = 'Debes seleccionar una moneda';
         _loading = false;
@@ -132,15 +136,13 @@ class _GlobalTransactionFormState extends State<_GlobalTransactionForm> {
           listen: false,
         );
         // Agregar la moneda manualmente si no existe
-        if (!currencyProvider.availableCurrencies.contains(
-          _currencyCode.toUpperCase(),
-        )) {
-          currencyProvider.addManualCurrency(_currencyCode.toUpperCase());
+        if (_currencyCode != null) {
+          final codeUC = _currencyCode!.toUpperCase();
+          if (!currencyProvider.availableCurrencies.contains(codeUC)) {
+            currencyProvider.addManualCurrency(codeUC);
+          }
+          currencyProvider.setRateForCurrency(codeUC, rateValue);
         }
-        currencyProvider.setRateForCurrency(
-          _currencyCode.toUpperCase(),
-          rateValue,
-        );
       }
     }
 
@@ -165,26 +167,36 @@ class _GlobalTransactionFormState extends State<_GlobalTransactionForm> {
         context,
         listen: false,
       );
-      final rate = currencyProvider.exchangeRates[_currencyCode.toUpperCase()];
-      if (rate != null && rate > 0) {
-        anchorUsdValue = amount / rate;
-        debugPrint(
-          '\u001b[41m[GLOBAL_FORM][CALC] amount=$amount, currency=$_currencyCode, rate=$rate, anchorUsdValue=$anchorUsdValue\u001b[0m',
-        );
-      } else if (_currencyCode.toUpperCase() == 'USD') {
-        anchorUsdValue = amount;
-        debugPrint(
-          '\u001b[41m[GLOBAL_FORM][CALC] amount=$amount, currency=USD, anchorUsdValue=$anchorUsdValue\u001b[0m',
-        );
+      double? rate;
+      if (_currencyCode != null) {
+        final codeUC = _currencyCode!.toUpperCase();
+        rate = currencyProvider.exchangeRates[codeUC];
+        if (rate != null && rate > 0) {
+          anchorUsdValue = amount / rate;
+          debugPrint(
+            '\u001b[41m[GLOBAL_FORM][CALC] amount=$amount, currency=$_currencyCode, rate=$rate, anchorUsdValue=$anchorUsdValue\u001b[0m',
+          );
+        } else if (codeUC == 'USD') {
+          anchorUsdValue = amount;
+          debugPrint(
+            '\u001b[41m[GLOBAL_FORM][CALC] amount=$amount, currency=USD, anchorUsdValue=$anchorUsdValue\u001b[0m',
+          );
+        } else {
+          anchorUsdValue = null;
+          debugPrint(
+            '\u001b[41m[GLOBAL_FORM][CALC][WARN] No rate for currency=$_currencyCode, anchorUsdValue=null\u001b[0m',
+          );
+        }
       } else {
         anchorUsdValue = null;
-        debugPrint(
-          '\u001b[41m[GLOBAL_FORM][CALC][WARN] No rate for currency=$_currencyCode, anchorUsdValue=null\u001b[0m',
-        );
       }
       // FIX: Asegurar que la fecha de la transacción siempre se guarde sin la hora (a medianoche).
       // La hora real de creación se guarda en `createdAt`. Esto es crucial para la consistencia del ordenamiento.
-      final normalizedDate = DateTime(_selectedDate.year, _selectedDate.month, _selectedDate.day);
+      final normalizedDate = DateTime(
+        _selectedDate.year,
+        _selectedDate.month,
+        _selectedDate.day,
+      );
 
       final transaction = Transaction(
         id: localId, // id local único
@@ -196,7 +208,7 @@ class _GlobalTransactionFormState extends State<_GlobalTransactionForm> {
         date: normalizedDate,
         createdAt: now,
         localId: localId,
-        currencyCode: _currencyCode,
+        currencyCode: _currencyCode!, // safe because already validated
         anchorUsdValue: anchorUsdValue,
       );
       debugPrint(
@@ -217,7 +229,10 @@ class _GlobalTransactionFormState extends State<_GlobalTransactionForm> {
       // estado inmediatamente y con el orden correcto. La lista de transacciones
       // necesita ser reconstruida para mostrar el nuevo ítem.
       if (!mounted) return;
-      final clientProvider = Provider.of<ClientProvider>(context, listen: false);
+      final clientProvider = Provider.of<ClientProvider>(
+        context,
+        listen: false,
+      );
       // Se recargan las transacciones para que la nueva aparezca inmediatamente.
       await txProvider.loadTransactions(widget.userId);
       // Se recargan los clientes para actualizar los saldos.
@@ -272,10 +287,12 @@ class _GlobalTransactionFormState extends State<_GlobalTransactionForm> {
     // final availableCurrencies = currencyProvider.availableCurrencies; // Eliminada variable no usada
     final allowedCurrencies = CurrencyProvider.allowedCurrencies;
     // Eliminada variable no usada: nonUsdCurrencies
+    final codeUC = _currencyCode?.toUpperCase();
     final rateMissing =
-        _currencyCode.toUpperCase() != 'USD' &&
-        (currencyProvider.exchangeRates[_currencyCode.toUpperCase()] == null ||
-            currencyProvider.exchangeRates[_currencyCode.toUpperCase()] == 0);
+        codeUC != null &&
+        codeUC != 'USD' &&
+        (currencyProvider.exchangeRates[codeUC] == null ||
+            currencyProvider.exchangeRates[codeUC] == 0);
     _rateFieldVisible = rateMissing;
     final rateValid =
         double.tryParse(_rateController.text.replaceAll(',', '.')) != null &&
@@ -499,16 +516,17 @@ class _GlobalTransactionFormState extends State<_GlobalTransactionForm> {
                   border: OutlineInputBorder(),
                   isDense: true,
                 ),
-                items:
-                    ['USD', ...allowedCurrencies.where((code) => code != 'USD')]
-                        .map(
-                          (code) =>
-                              DropdownMenuItem(value: code, child: Text(code)),
-                        )
-                        .toList(),
+                items: [
+                  ...[
+                    'USD',
+                    ...allowedCurrencies.where((code) => code != 'USD'),
+                  ].map(
+                    (code) => DropdownMenuItem(value: code, child: Text(code)),
+                  ),
+                ],
                 onChanged: (code) {
                   setState(() {
-                    _currencyCode = code ?? 'VES';
+                    _currencyCode = code;
                     _rateController.text = '';
                   });
                 },
@@ -524,7 +542,9 @@ class _GlobalTransactionFormState extends State<_GlobalTransactionForm> {
             child: TextField(
               controller: _rateController,
               decoration: InputDecoration(
-                labelText: 'Tasa ${_currencyCode.toUpperCase()} a USD',
+                labelText:
+                    'Tasa  {_currencyCode?.toUpperCase() ?? '
+                    '} a USD',
                 border: OutlineInputBorder(),
                 isDense: true,
                 prefixIcon: Icon(Icons.attach_money_rounded),

--- a/lib/widgets/client_form.dart
+++ b/lib/widgets/client_form.dart
@@ -230,7 +230,7 @@ class _ClientFormState extends State<ClientForm> {
     'NZD',
     'ZAR',
   ];
-  String? _selectedCurrency = 'USD';
+  String? _selectedCurrency;
   @override
   void initState() {
     super.initState();
@@ -307,13 +307,14 @@ class _ClientFormState extends State<ClientForm> {
       }
       // --- Cálculo de anchorUsdValue ---
       final provider = Provider.of<CurrencyProvider>(context, listen: false);
-      final rate = provider.exchangeRates[_selectedCurrency!.toUpperCase()];
+      final codeUC = _selectedCurrency!.toUpperCase();
+      final rate = provider.exchangeRates[codeUC];
       if (rate != null && rate > 0) {
         anchorUsdValue = balance / rate;
         debugPrint(
           '\u001b[41m[FORM][CALC] balance=$balance, currency=$_selectedCurrency, rate=$rate, anchorUsdValue=$anchorUsdValue\u001b[0m',
         );
-      } else if (_selectedCurrency!.toUpperCase() == 'USD') {
+      } else if (codeUC == 'USD') {
         anchorUsdValue = balance;
         debugPrint(
           '\u001b[41m[FORM][CALC] balance=$balance, currency=USD, anchorUsdValue=$anchorUsdValue\u001b[0m',
@@ -348,7 +349,7 @@ class _ClientFormState extends State<ClientForm> {
       balance: type == 'debt' ? -balance : balance,
       synced: widget.initialClient?.synced ?? false,
       pendingDelete: widget.initialClient?.pendingDelete ?? false,
-      currencyCode: _selectedCurrency ?? 'USD',
+      currencyCode: _selectedCurrency!, // safe, ya validado
       anchorUsdValue: anchorUsdValue, // <-- Ahora sí se pasa correctamente
     );
     debugPrint(
@@ -803,12 +804,14 @@ class _ClientFormState extends State<ClientForm> {
                                 border: OutlineInputBorder(),
                                 isDense: true,
                               ),
-                              items: currencyList.map((currency) {
-                                return DropdownMenuItem<String>(
-                                  value: currency,
-                                  child: Text(currency),
-                                );
-                              }).toList(),
+                              items: [
+                                ...currencyList.map(
+                                  (currency) => DropdownMenuItem<String>(
+                                    value: currency,
+                                    child: Text(currency),
+                                  ),
+                                ),
+                              ],
                               onChanged: (value) async {
                                 if (value == null) return;
 

--- a/lib/widgets/client_form.dart
+++ b/lib/widgets/client_form.dart
@@ -254,9 +254,17 @@ class _ClientFormState extends State<ClientForm> {
   void _save() async {
     if (!mounted) return;
     // Validaciones antes de mostrar loading
-    if (_nameController.text.trim().isEmpty) {
+    final nameText = _nameController.text.trim();
+    if (nameText.isEmpty) {
       setState(() {
         _error = 'El nombre es obligatorio';
+        _isSaving = false;
+      });
+      return;
+    }
+    if (nameText.length > 27) {
+      setState(() {
+        _error = 'El nombre no puede tener más de 27 caracteres';
         _isSaving = false;
       });
       return;
@@ -457,6 +465,7 @@ class _ClientFormState extends State<ClientForm> {
                   const SizedBox(height: 14),
                   TextField(
                     controller: _nameController,
+                    maxLength: 27,
                     decoration: InputDecoration(
                       labelText: 'Nombre',
                       prefixIcon: const Icon(Icons.person_outline),
@@ -478,6 +487,7 @@ class _ClientFormState extends State<ClientForm> {
                         vertical: 16,
                         horizontal: 12,
                       ),
+                      counterText: '',
                     ),
                   ),
                   const SizedBox(height: 14),

--- a/lib/widgets/faq_help_sheet.dart
+++ b/lib/widgets/faq_help_sheet.dart
@@ -44,7 +44,7 @@ class FaqHelpSheet extends StatelessWidget {
             ),
             const SizedBox(height: 20),
             const Text(
-              'Sección Moneda:',
+              'Seccion monedas:',
               style: TextStyle(fontWeight: FontWeight.bold),
             ),
             ListTile(
@@ -52,9 +52,9 @@ class FaqHelpSheet extends StatelessWidget {
                 Icons.attach_money_rounded,
                 color: Colors.indigo,
               ),
-              title: const Text('Toggle USD:'),
+              title: const Text('Gestion de Monedas'),
               subtitle: const Text(
-                'Los montos en moneda local pueden convertirse a USD según la tasa que definas en la app.',
+                'Puedes registrar la tasa de cambio de la moneda que desee. La app realiza la conversión automáticamente.',
               ),
             ),
             const SizedBox(height: 16),
@@ -120,6 +120,15 @@ class FaqHelpSheet extends StatelessWidget {
             ListTile(
               leading: const Icon(Icons.calendar_today, color: Colors.indigo),
               title: const Text('Calendario: Filtra transacciones por fecha.'),
+            ),
+            ListTile(
+              leading: const Icon(Icons.monetization_on, color: Colors.indigo),
+              title: const Text(
+                'Selector de moneda: Cambia la moneda en la que ves los montos.',
+              ),
+              subtitle: const Text(
+                'Toca la moneda (ej: USD, EUR, etc.) para ver todos los valores y totales en esa moneda.',
+              ),
             ),
             ListTile(
               leading: const Icon(Icons.delete, color: Colors.red),

--- a/lib/widgets/general_receipt_modal.dart
+++ b/lib/widgets/general_receipt_modal.dart
@@ -425,7 +425,7 @@ class _GeneralReceiptModalState extends State<GeneralReceiptModal> {
                             ),
                           );
                           // Diálogo de selección de monedas
-                          List<String> selected = [registeredCurrencies.first];
+                          List<String> selected = [];
                           await showDialog(
                             context: context,
                             builder: (ctx) {
@@ -433,7 +433,7 @@ class _GeneralReceiptModalState extends State<GeneralReceiptModal> {
                                 builder: (ctx, setStateDialog) {
                                   return AlertDialog(
                                     title: const Text(
-                                      'Selecciona monedas (máx 2)',
+                                      'Selecciona monedas (máximo 2)',
                                     ),
                                     content: Wrap(
                                       spacing: 8,
@@ -453,9 +453,7 @@ class _GeneralReceiptModalState extends State<GeneralReceiptModal> {
                                                   selected.add(symbol);
                                                 }
                                               } else {
-                                                if (selected.length > 1) {
-                                                  selected.remove(symbol);
-                                                }
+                                                selected.remove(symbol);
                                               }
                                             });
                                           },
@@ -464,8 +462,9 @@ class _GeneralReceiptModalState extends State<GeneralReceiptModal> {
                                     ),
                                     actions: [
                                       TextButton(
-                                        onPressed: () =>
-                                            Navigator.of(ctx).pop(),
+                                        onPressed: selected.isEmpty
+                                            ? null
+                                            : () => Navigator.of(ctx).pop(),
                                         child: const Text('Aceptar'),
                                       ),
                                     ],

--- a/lib/widgets/general_receipt_modal.dart
+++ b/lib/widgets/general_receipt_modal.dart
@@ -413,27 +413,85 @@ class _GeneralReceiptModalState extends State<GeneralReceiptModal> {
                                 context,
                                 listen: false,
                               );
-                          // Lógica corregida para la exportación a PDF
-                          final selectedCurrency = currencyProvider.currency;
-                          final shouldConvertToSecondary =
-                              selectedCurrency != 'USD';
-                          final conversionRate =
-                              currencyProvider.getRateFor(selectedCurrency) ??
-                              1.0;
-
+                          // Obtener monedas registradas y tasas
+                          final registeredCurrencies =
+                              currencyProvider.availableCurrencies;
+                          final rates = Map.fromEntries(
+                            registeredCurrencies.map(
+                              (symbol) => MapEntry(
+                                symbol,
+                                currencyProvider.getRateFor(symbol) ?? 1.0,
+                              ),
+                            ),
+                          );
+                          // Diálogo de selección de monedas
+                          List<String> selected = [registeredCurrencies.first];
+                          await showDialog(
+                            context: context,
+                            builder: (ctx) {
+                              return StatefulBuilder(
+                                builder: (ctx, setStateDialog) {
+                                  return AlertDialog(
+                                    title: const Text(
+                                      'Selecciona monedas (máx 2)',
+                                    ),
+                                    content: Wrap(
+                                      spacing: 8,
+                                      children: registeredCurrencies.map((
+                                        symbol,
+                                      ) {
+                                        final isSelected = selected.contains(
+                                          symbol,
+                                        );
+                                        return ChoiceChip(
+                                          label: Text(symbol),
+                                          selected: isSelected,
+                                          onSelected: (val) {
+                                            setStateDialog(() {
+                                              if (val) {
+                                                if (selected.length < 2) {
+                                                  selected.add(symbol);
+                                                }
+                                              } else {
+                                                if (selected.length > 1) {
+                                                  selected.remove(symbol);
+                                                }
+                                              }
+                                            });
+                                          },
+                                        );
+                                      }).toList(),
+                                    ),
+                                    actions: [
+                                      TextButton(
+                                        onPressed: () =>
+                                            Navigator.of(ctx).pop(),
+                                        child: const Text('Aceptar'),
+                                      ),
+                                    ],
+                                  );
+                                },
+                              );
+                            },
+                          );
+                          // Construir la lista de monedas seleccionadas con símbolo y tasa
+                          final selectedCurrencies = selected
+                              .map(
+                                (symbol) => {
+                                  'symbol': symbol,
+                                  'rate': rates[symbol] ?? 1.0,
+                                },
+                              )
+                              .toList();
                           if (isMobile) {
                             await exportAndShareGeneralReceiptWithMovementsPDF(
                               filtered,
-                              convertCurrency: shouldConvertToSecondary,
-                              conversionRate: conversionRate,
-                              currencySymbol: selectedCurrency,
+                              selectedCurrencies: selectedCurrencies,
                             );
                           } else {
                             await exportGeneralReceiptWithMovementsPDF(
                               filtered,
-                              convertCurrency: shouldConvertToSecondary,
-                              conversionRate: conversionRate,
-                              currencySymbol: selectedCurrency,
+                              selectedCurrencies: selectedCurrencies,
                             );
                           }
                         },

--- a/lib/widgets/transaction_form.dart
+++ b/lib/widgets/transaction_form.dart
@@ -27,6 +27,7 @@ class TransactionForm extends StatefulWidget {
 class _TransactionFormState extends State<TransactionForm> {
   final _amountController = TextEditingController();
   final _descriptionController = TextEditingController();
+  static const int _descriptionMaxLength = 30;
   String? _type; // No seleccionado por defecto
   String? _currencyCode;
   DateTime _selectedDate = DateTime.now();
@@ -93,12 +94,22 @@ class _TransactionFormState extends State<TransactionForm> {
       logError('Monto inválido');
       return;
     }
-    if (_descriptionController.text.trim().isEmpty) {
+    final descriptionText = _descriptionController.text.trim();
+    if (descriptionText.isEmpty) {
       setState(() {
         _error = 'Descripción obligatoria';
         _loading = false;
       });
       logError('Descripción obligatoria');
+      return;
+    }
+    if (descriptionText.length > _descriptionMaxLength) {
+      setState(() {
+        _error =
+            'La descripción no puede superar los $_descriptionMaxLength caracteres';
+        _loading = false;
+      });
+      logError('Descripción demasiado larga');
       return;
     }
     // Validar y guardar tasa solo si el campo está visible
@@ -553,8 +564,33 @@ class _TransactionFormState extends State<TransactionForm> {
                         ),
                         prefixIcon: Icon(Icons.description),
                         isDense: true,
+                        counterText: '',
                       ),
                       maxLines: 2,
+                      maxLength: _descriptionMaxLength,
+                      buildCounter:
+                          (
+                            BuildContext context, {
+                            required int currentLength,
+                            required bool isFocused,
+                            required int? maxLength,
+                          }) {
+                            return Padding(
+                              padding: const EdgeInsets.only(
+                                right: 8.0,
+                                top: 2.0,
+                              ),
+                              child: Text(
+                                '$currentLength/$_descriptionMaxLength',
+                                style: TextStyle(
+                                  fontSize: 12,
+                                  color: currentLength > _descriptionMaxLength
+                                      ? Colors.red
+                                      : Colors.grey,
+                                ),
+                              ),
+                            );
+                          },
                     ),
                     if (_error != null)
                       Padding(


### PR DESCRIPTION
- Refactorizado el flujo de generación de PDF para recibos generales: ahora el usuario debe seleccionar explícitamente una o dos monedas antes de generar el PDF, sin ninguna preseleccionada y siendo obligatorio al menos una.
- Las columnas del PDF se generan dinámicamente según las monedas seleccionadas.
- Se muestran los totales para todas las monedas seleccionadas, no solo USD.
- Se invirtió el orden de las columnas de totales en el PDF para mayor claridad.
- Se mejoró la visualización de la columna 'Deuda Pendiente' en el PDF.
- Se mejoró la experiencia de usuario en el modal de selección de monedas.